### PR TITLE
Disable wayland socket

### DIFF
--- a/com.github.Anuken.Mindustry.yml
+++ b/com.github.Anuken.Mindustry.yml
@@ -8,7 +8,6 @@ sdk-extensions:
 command: mindustry.sh
 finish-args:
   - --socket=fallback-x11
-  - --socket=wayland
   - --socket=pulseaudio
   - --device=dri
   - --env=PATH=/usr/bin:/app/bin:/app/jre/bin


### PR DESCRIPTION
Mindustry doesn't yet support wayland as a backend. It also crashes
when it notices a wayland socket.

Fixes #1