### PR TITLE
add Categories entry to desktop file

### DIFF
--- a/com.github.Anuken.Mindustry.desktop
+++ b/com.github.Anuken.Mindustry.desktop
@@ -6,3 +6,4 @@ Comment=Mindustry: A sandbox tower-defense game.
 Icon=com.github.Anuken.Mindustry
 Terminal=false
 Exec=mindustry.sh
+Categories=Game;


### PR DESCRIPTION
The Mindustry desktop file is missing the Categories entry. Without it Mindustry doesn't get correctly placed into the desktop start menus. This patch fixes this issue.