### PR TITLE
metainfo: Note chat functionality in OARS rating

### DIFF
--- a/com.github.Anuken.Mindustry.metainfo.xml
+++ b/com.github.Anuken.Mindustry.metainfo.xml
@@ -42,5 +42,6 @@
     <content_attribute id="violence-cartoon">intense</content_attribute>
     <content_attribute id="violence-fantasy">intense</content_attribute>
     <content_attribute id="violence-realistic">mild</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
  </content_rating>
 </component>


### PR DESCRIPTION
Set social-chat to intense, since Mindustry's multiplayer mode has text chat.