### PR TITLE
Only build for x86_64

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "automerge-flathubbot-prs": true
+  "automerge-flathubbot-prs": true,
+  "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
Mindustry does not support arm[0].
This enables only the build for x86_64[1].

Fixes #66.

[0]: https://github.com/Anuken/Arc/issues/167
[1]: https://docs.flathub.org/docs/for-app-authors/maintenance#limiting-the-set-of-architectures-to-build-on